### PR TITLE
Fix UBTU-22-612040: baseline pam_pkcs11.conf when absent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Ubuntu22STIG
 
+## Hotfix - UBTU-22-612040 pam_pkcs11.conf baseline (addresses #30)
+
+- UBTU-22-612040: create a baseline /etc/pam_pkcs11/pam_pkcs11.conf when absent under disruption_high, and drop backrefs from the use_mappers lineinfile so the STIG scanner check for V-260579 no longer fails on systems without the pam-pkcs11 package (addresses #30). Note: a custom use_mappers value is replaced with pwent.
+
 ## V2R7 - QA cycle (no benchmark version change)
 
 Repo hygiene and pattern fixes (no rule additions, removals, or content changes):

--- a/tasks/Cat1/UBTU-22-61xxxx.yml
+++ b/tasks/Cat1/UBTU-22-61xxxx.yml
@@ -55,7 +55,7 @@
       ansible.builtin.import_tasks:
         file: warning_facts.yml
 
-- name: HIGH | UBTU-22-612040 | PATCH | Ensure /etc/pam_pkcs11/ directory exists for STIG scanner compliance (V-260579)
+- name: HIGH | UBTU-22-612040 | PATCH | Ubuntu 22.04 LTS must map the authenticated identity to the user or group account for PKI-based authentication | Baseline pam_pkcs11.conf
   when:
     - ubtu22stig_612040
     - ubtu22stig_disruption_high
@@ -68,48 +68,23 @@
     - V-260579
     - NIST800-53R4_IA-5
     - multifactor
-  ansible.builtin.file:
-    path: /etc/pam_pkcs11
-    state: directory
-    owner: root
-    group: root
-    mode: 'go-w'
+  block:
+    - name: HIGH | UBTU-22-612040 | PATCH | Ubuntu 22.04 LTS must map the authenticated identity to the user or group account for PKI-based authentication | Create directory
+      ansible.builtin.file:
+        path: /etc/pam_pkcs11
+        state: directory
+        owner: root
+        group: root
+        mode: 'go-w'
 
-- name: HIGH | UBTU-22-612040 | PATCH | Create baseline /etc/pam_pkcs11/pam_pkcs11.conf if absent for STIG scanner compliance (V-260579)
-  when:
-    - ubtu22stig_612040
-    - ubtu22stig_disruption_high
-  tags:
-    - UBTU-22-612040
-    - CAT1
-    - CCI-000187
-    - SRG-OS-000068-GPOS-00036
-    - SV-260579r958452_rule
-    - V-260579
-    - NIST800-53R4_IA-5
-    - multifactor
-  ansible.builtin.copy:
-    dest: /etc/pam_pkcs11/pam_pkcs11.conf
-    force: false
-    owner: root
-    group: root
-    mode: 'go-w'
-    content: |
-      {{ file_managed_by_ansible }}
-      # Baseline file for STIG V-260579 (UBTU-22-612040). Created when
-      # /etc/pam_pkcs11/pam_pkcs11.conf is absent; pam-pkcs11 package may or
-      # may not be installed. Adjust pkcs11_module path for the host arch
-      # if pam-pkcs11 is later installed and used.
-      pam_pkcs11 {
-        use_mappers = pwent;
-        use_pkcs11_module = opensc;
-        pkcs11_module opensc {
-          module = /usr/lib/x86_64-linux-gnu/opensc-pkcs11.so;
-        }
-        mapper pwent {
-          module = internal;
-        }
-      }
+    - name: HIGH | UBTU-22-612040 | PATCH | Ubuntu 22.04 LTS must map the authenticated identity to the user or group account for PKI-based authentication | Deploy baseline config when absent
+      ansible.builtin.template:
+        src: etc/pam_pkcs11/pam_pkcs11.conf.j2
+        dest: /etc/pam_pkcs11/pam_pkcs11.conf
+        owner: root
+        group: root
+        mode: 'go-w'
+        force: false
 
 - name: HIGH | UBTU-22-612040 | PATCH | Ubuntu 22.04 LTS must map the authenticated identity to the user or group account for PKI-based authentication.
   when:

--- a/tasks/Cat1/UBTU-22-61xxxx.yml
+++ b/tasks/Cat1/UBTU-22-61xxxx.yml
@@ -55,6 +55,62 @@
       ansible.builtin.import_tasks:
         file: warning_facts.yml
 
+- name: HIGH | UBTU-22-612040 | PATCH | Ensure /etc/pam_pkcs11/ directory exists for STIG scanner compliance (V-260579)
+  when:
+    - ubtu22stig_612040
+    - ubtu22stig_disruption_high
+  tags:
+    - UBTU-22-612040
+    - CAT1
+    - CCI-000187
+    - SRG-OS-000068-GPOS-00036
+    - SV-260579r958452_rule
+    - V-260579
+    - NIST800-53R4_IA-5
+    - multifactor
+  ansible.builtin.file:
+    path: /etc/pam_pkcs11
+    state: directory
+    owner: root
+    group: root
+    mode: 'go-w'
+
+- name: HIGH | UBTU-22-612040 | PATCH | Create baseline /etc/pam_pkcs11/pam_pkcs11.conf if absent for STIG scanner compliance (V-260579)
+  when:
+    - ubtu22stig_612040
+    - ubtu22stig_disruption_high
+  tags:
+    - UBTU-22-612040
+    - CAT1
+    - CCI-000187
+    - SRG-OS-000068-GPOS-00036
+    - SV-260579r958452_rule
+    - V-260579
+    - NIST800-53R4_IA-5
+    - multifactor
+  ansible.builtin.copy:
+    dest: /etc/pam_pkcs11/pam_pkcs11.conf
+    force: false
+    owner: root
+    group: root
+    mode: 'go-w'
+    content: |
+      {{ file_managed_by_ansible }}
+      # Baseline file for STIG V-260579 (UBTU-22-612040). Created when
+      # /etc/pam_pkcs11/pam_pkcs11.conf is absent; pam-pkcs11 package may or
+      # may not be installed. Adjust pkcs11_module path for the host arch
+      # if pam-pkcs11 is later installed and used.
+      pam_pkcs11 {
+        use_mappers = pwent;
+        use_pkcs11_module = opensc;
+        pkcs11_module opensc {
+          module = /usr/lib/x86_64-linux-gnu/opensc-pkcs11.so;
+        }
+        mapper pwent {
+          module = internal;
+        }
+      }
+
 - name: HIGH | UBTU-22-612040 | PATCH | Ubuntu 22.04 LTS must map the authenticated identity to the user or group account for PKI-based authentication.
   when:
     - ubtu22stig_612040
@@ -70,6 +126,5 @@
     - multifactor
   ansible.builtin.lineinfile:
     path: /etc/pam_pkcs11/pam_pkcs11.conf
-    backrefs: true
-    regexp: ^(|#)use_mappers\s*=(.*(?!pwent))
-    line: use_mappers = \1,pwent
+    regexp: '^[#\s]*use_mappers\s*='
+    line: 'use_mappers = pwent'

--- a/templates/etc/pam_pkcs11/pam_pkcs11.conf.j2
+++ b/templates/etc/pam_pkcs11/pam_pkcs11.conf.j2
@@ -1,0 +1,15 @@
+{{ file_managed_by_ansible }}
+# Baseline file for STIG V-260579 (UBTU-22-612040). Created when
+# /etc/pam_pkcs11/pam_pkcs11.conf is absent; pam-pkcs11 package may or
+# may not be installed. Adjust pkcs11_module path for the host arch
+# if pam-pkcs11 is later installed and used.
+pam_pkcs11 {
+  use_mappers = pwent;
+  use_pkcs11_module = opensc;
+  pkcs11_module opensc {
+    module = /usr/lib/x86_64-linux-gnu/opensc-pkcs11.so;
+  }
+  mapper pwent {
+    module = internal;
+  }
+}

--- a/templates/etc/pam_pkcs11/pam_pkcs11.conf.j2
+++ b/templates/etc/pam_pkcs11/pam_pkcs11.conf.j2
@@ -1,4 +1,5 @@
 {{ file_managed_by_ansible }}
+
 # Baseline file for STIG V-260579 (UBTU-22-612040). Created when
 # /etc/pam_pkcs11/pam_pkcs11.conf is absent; pam-pkcs11 package may or
 # may not be installed. Adjust pkcs11_module path for the host arch


### PR DESCRIPTION
Please ensure that you have understood the contributing guide.

Ensure all commits are signed-off and gpg signed.

**Overall Review of Changes:**
Fixes UBTU-22-612040 so STIG scanners no longer fail V-260579 (Cat I) on systems where /etc/pam_pkcs11/pam_pkcs11.conf is absent. A baseline pam_pkcs11.conf is now created from a template (only when the file is absent, under disruption_high), and the use_mappers lineinfile no longer relies on backrefs (which silently skipped on fresh files).

**Issue Fixes:**
- Addresses #30 - baseline /etc/pam_pkcs11/pam_pkcs11.conf is created when absent so the scanner's `use_mappers = pwent` check passes regardless of whether the pam-pkcs11 package is installed. Note: a custom use_mappers value is replaced with pwent.

**Enhancements:**
- N/A

**How has this been tested?:**
yamllint and ansible-lint pass (0/0) on the changed task and template. The baseline is deployed with `force: false` so it never clobbers an existing real config.